### PR TITLE
fix: resolve worker file correctly

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -22,7 +22,7 @@ const PRETTIER_STATIC_PROPERTIES = ["version", "util", "doc"];
 let worker;
 function createWorker() {
   if (!worker) {
-    worker = new Worker("./worker.js");
+    worker = new Worker(require.resolve("./worker.js"));
     worker.unref();
   }
 


### PR DESCRIPTION
A relative path is resolved relative to `cwd`. So outside of this repo, the worker cannot be instantiated.

Passing an absolute path fixes it