### PR TITLE
fix: add peer dependency on Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
       "text"
     ]
   },
+  "peerDependencies": {
+    "prettier": "^3.0.0"
+  },
   "devDependencies": {
     "c8": "7.12.0",
     "npm-run-all": "4.1.5",


### PR DESCRIPTION
E.g. Yarn PnP and pnpm requires a dependency to be declared