### PR TITLE
Check type declarations with JSDoc comments

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -8,7 +8,7 @@ const {
 const url = require("url");
 const path = require("path");
 
-const PRETTIER_ASYNC_FUNCTIONS = [
+const PRETTIER_ASYNC_FUNCTIONS = /** @type {const} */ ([
   "formatWithCursor",
   "format",
   "check",
@@ -17,10 +17,15 @@ const PRETTIER_ASYNC_FUNCTIONS = [
   "clearConfigCache",
   "getFileInfo",
   "getSupportInfo",
-];
+]);
 
-const PRETTIER_STATIC_PROPERTIES = ["version", "util", "doc"];
+const PRETTIER_STATIC_PROPERTIES = /** @type {const} */ ([
+  "version",
+  "util",
+  "doc",
+]);
 
+/** @type {Worker | undefined} */
 let worker;
 function createWorker() {
   if (!worker) {
@@ -31,6 +36,12 @@ function createWorker() {
   return worker;
 }
 
+/**
+ * @template {keyof PrettierSyncFunctions} FunctionName
+ * @param {FunctionName} functionName
+ * @param {string} prettierEntry
+ * @returns {PrettierSyncFunction<FunctionName>}
+ */
 function createSyncFunction(functionName, prettierEntry) {
   return (...args) => {
     const signal = new Int32Array(new SharedArrayBuffer(4));
@@ -56,10 +67,19 @@ function createSyncFunction(functionName, prettierEntry) {
   };
 }
 
+/**
+ * @template {keyof PrettierStaticProperties} Property
+ * @param {Property} property
+ * @param {string} prettierEntry
+ */
 function getProperty(property, prettierEntry) {
-  return require(prettierEntry)[property];
+  return /** @type {Prettier} */ (require(prettierEntry))[property];
 }
 
+/**
+ * @template {keyof SynchronizedPrettier} ExportName
+ * @param {() => SynchronizedPrettier[ExportName]} getter
+ */
 function createDescriptor(getter) {
   let value;
   return {
@@ -71,6 +91,9 @@ function createDescriptor(getter) {
   };
 }
 
+/**
+ * @param {string | URL} entry
+ */
 function toImportId(entry) {
   if (entry instanceof URL) {
     return entry.href;
@@ -83,6 +106,9 @@ function toImportId(entry) {
   return entry;
 }
 
+/**
+ * @param {string | URL} entry
+ */
 function toRequireId(entry) {
   if (entry instanceof URL || entry.startsWith("file:")) {
     return url.fileURLToPath(entry);
@@ -91,6 +117,11 @@ function toRequireId(entry) {
   return entry;
 }
 
+/**
+ * @param {object} options
+ * @param {string | URL} options.prettierEntry - Path or URL to prettier entry.
+ * @returns {SynchronizedPrettier}
+ */
 function createSynchronizedPrettier({ prettierEntry }) {
   const importId = toImportId(prettierEntry);
   const requireId = toRequireId(prettierEntry);
@@ -99,15 +130,21 @@ function createSynchronizedPrettier({ prettierEntry }) {
     Object.create(null),
     Object.fromEntries(
       [
-        ...PRETTIER_ASYNC_FUNCTIONS.map((functionName) => [
-          functionName,
-          () => createSyncFunction(functionName, importId),
-        ]),
-        ...PRETTIER_STATIC_PROPERTIES.map((property) => [
-          property,
-          () => getProperty(property, requireId),
-        ]),
-      ].map(([property, getter]) => [property, createDescriptor(getter)]),
+        ...PRETTIER_ASYNC_FUNCTIONS.map((functionName) => {
+          return /** @type {const} */ ([
+            functionName,
+            () => createSyncFunction(functionName, importId),
+          ]);
+        }),
+        ...PRETTIER_STATIC_PROPERTIES.map((property) => {
+          return /** @type {const} */ ([
+            property,
+            () => getProperty(property, requireId),
+          ]);
+        }),
+      ].map(([property, getter]) => {
+        return /** @type {const} */ ([property, createDescriptor(getter)]);
+      }),
     ),
   );
 
@@ -115,4 +152,17 @@ function createSynchronizedPrettier({ prettierEntry }) {
 }
 
 module.exports = createSynchronizedPrettier({ prettierEntry: "prettier" });
+// @ts-expect-error Property 'createSynchronizedPrettier' for named export compatibility
 module.exports.createSynchronizedPrettier = createSynchronizedPrettier;
+
+/**
+ * @typedef {import('prettier')} Prettier
+ * @typedef {PrettierSyncFunctions & PrettierStaticProperties} SynchronizedPrettier
+ * @typedef {{ [FunctionName in typeof PRETTIER_ASYNC_FUNCTIONS[number]]: PrettierSyncFunction<FunctionName> }} PrettierSyncFunctions
+ * @typedef {{ [PropertyName in typeof PRETTIER_STATIC_PROPERTIES[number]]: Prettier[PropertyName] }} PrettierStaticProperties
+ */
+
+/**
+ * @template {keyof PrettierSyncFunctions} FunctionName
+ * @typedef {(...args: Parameters<Prettier[FunctionName]>) => Awaited<ReturnType<Prettier[FunctionName]>> } PrettierSyncFunction
+ */

--- a/index.cjs
+++ b/index.cjs
@@ -8,7 +8,6 @@ const {
 const url = require("url");
 const path = require("path");
 
-
 /**
 @template {keyof PrettierSynchronizedFunctions} FunctionName
 @typedef {(...args: Parameters<Prettier[FunctionName]>) => Awaited<ReturnType<Prettier[FunctionName]>> } PrettierSyncFunction

--- a/index.d.cts
+++ b/index.d.cts
@@ -1,0 +1,40 @@
+type Prettier = typeof import("prettier");
+
+type SynchronizedPrettier = {
+  // Prettier static properties
+  version: Prettier["version"];
+  util: Prettier["util"];
+  doc: Prettier["doc"];
+
+  // Prettier functions
+  formatWithCursor: PrettierSyncFunction<"formatWithCursor">;
+  format: PrettierSyncFunction<"format">;
+  check: PrettierSyncFunction<"check">;
+  resolveConfig: PrettierSyncFunction<"resolveConfig">;
+  resolveConfigFile: PrettierSyncFunction<"resolveConfigFile">;
+  clearConfigCache: PrettierSyncFunction<"clearConfigCache">;
+  getFileInfo: PrettierSyncFunction<"getFileInfo">;
+  getSupportInfo: PrettierSyncFunction<"getSupportInfo">;
+};
+
+type PrettierSyncFunction<
+  FunctionName extends
+    | "formatWithCursor"
+    | "format"
+    | "check"
+    | "resolveConfig"
+    | "resolveConfigFile"
+    | "clearConfigCache"
+    | "getFileInfo"
+    | "getSupportInfo",
+> = (
+  ...args: Parameters<Prettier[FunctionName]>
+) => Awaited<ReturnType<Prettier[FunctionName]>>;
+
+declare const prettierSync: SynchronizedPrettier & {
+  createSynchronizedPrettier: (options: {
+    prettierEntry: string | URL;
+  }) => SynchronizedPrettier;
+};
+
+export = prettierSync;

--- a/index.d.cts
+++ b/index.d.cts
@@ -7,17 +7,17 @@ type SynchronizedPrettier = {
   doc: Prettier["doc"];
 
   // Prettier functions
-  formatWithCursor: PrettierSyncFunction<"formatWithCursor">;
-  format: PrettierSyncFunction<"format">;
-  check: PrettierSyncFunction<"check">;
-  resolveConfig: PrettierSyncFunction<"resolveConfig">;
-  resolveConfigFile: PrettierSyncFunction<"resolveConfigFile">;
-  clearConfigCache: PrettierSyncFunction<"clearConfigCache">;
-  getFileInfo: PrettierSyncFunction<"getFileInfo">;
-  getSupportInfo: PrettierSyncFunction<"getSupportInfo">;
+  formatWithCursor: PrettierSynchronizedFunction<"formatWithCursor">;
+  format: PrettierSynchronizedFunction<"format">;
+  check: PrettierSynchronizedFunction<"check">;
+  resolveConfig: PrettierSynchronizedFunction<"resolveConfig">;
+  resolveConfigFile: PrettierSynchronizedFunction<"resolveConfigFile">;
+  clearConfigCache: PrettierSynchronizedFunction<"clearConfigCache">;
+  getFileInfo: PrettierSynchronizedFunction<"getFileInfo">;
+  getSupportInfo: PrettierSynchronizedFunction<"getSupportInfo">;
 };
 
-type PrettierSyncFunction<
+type PrettierSynchronizedFunction<
   FunctionName extends
     | "formatWithCursor"
     | "format"
@@ -31,10 +31,10 @@ type PrettierSyncFunction<
   ...args: Parameters<Prettier[FunctionName]>
 ) => Awaited<ReturnType<Prettier[FunctionName]>>;
 
-declare const prettierSync: SynchronizedPrettier & {
+declare const synchronizedPrettier: SynchronizedPrettier & {
   createSynchronizedPrettier: (options: {
     prettierEntry: string | URL;
   }) => SynchronizedPrettier;
 };
 
-export = prettierSync;
+export = synchronizedPrettier;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "sideEffects": false,
   "type": "module",
+  "main": "./index.cjs",
   "exports": {
     ".": {
       "require": "./index.cjs",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "prettier": "^3.0.0"
   },
   "devDependencies": {
+    "@types/node": "20.4.1",
     "c8": "8.0.0",
     "npm-run-all": "4.1.5",
     "prettier": "3.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "exports": {
     ".": {
       "types": "./index.d.cts",
-      "require": "./index.cjs",
       "default": "./index.cjs"
     },
     "./*": "./*"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,13 @@
   },
   "sideEffects": false,
   "type": "module",
-  "exports": "./index.cjs",
+  "exports": {
+    ".": {
+      "require": "./index.cjs",
+      "default": "./index.cjs"
+    },
+    "./*": "./*"
+  },
   "files": [
     "index.cjs",
     "worker.js"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "main": "./index.cjs",
   "exports": {
     ".": {
+      "types": "./index.d.cts",
       "require": "./index.cjs",
       "default": "./index.cjs"
     },
@@ -26,6 +27,7 @@
   },
   "files": [
     "index.cjs",
+    "index.d.cts",
     "worker.js"
   ],
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -25,9 +25,9 @@ yarn add prettier @prettier/sync
 ## Usage
 
 ```js
-import prettierSync from "@prettier/sync";
+import synchronizedPrettier from "@prettier/sync";
 
-prettierSync.format("foo( )", { parser: "babel" });
+synchronizedPrettier.format("foo( )", { parser: "babel" });
 // => 'foo();\n'
 ```
 
@@ -46,10 +46,10 @@ Path or URL to prettier entry.
 ```js
 import { createSynchronizedPrettier } from "@prettier/sync";
 
-const prettierSync = createSynchronizedPrettier({
+const synchronizedPrettier = createSynchronizedPrettier({
   prettierEntry: "/path/to/prettier/index.js",
 });
 
-prettierSync.format("foo( )", { parser: "babel" });
+synchronizedPrettier.format("foo( )", { parser: "babel" });
 // => 'foo();\n'
 ```

--- a/test.js
+++ b/test.js
@@ -37,7 +37,9 @@ test("version", () => {
     fileURLToPath(fakePrettierUrl),
   ]) {
     test(prettierEntry, async () => {
-      const fakeSynchronizedPrettier = createSynchronizedPrettier({ prettierEntry });
+      const fakeSynchronizedPrettier = createSynchronizedPrettier({
+        prettierEntry,
+      });
       assert.equal(fakeSynchronizedPrettier.version, fakePrettier.version);
       assert.equal(
         fakeSynchronizedPrettier.format("code"),

--- a/test.js
+++ b/test.js
@@ -3,19 +3,19 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import prettier from "prettier";
-import prettierSync, { createSynchronizedPrettier } from "./index.cjs";
+import synchronizedPrettier, { createSynchronizedPrettier } from "./index.cjs";
 
 test("format", async () => {
   const code = await fs.readFile("./index.cjs", "utf8");
   const formatOptions = { parser: "meriyah" };
   assert.equal(
-    prettierSync.format(code, formatOptions),
+    synchronizedPrettier.format(code, formatOptions),
     await prettier.format(code, formatOptions),
   );
 
   let error;
   try {
-    prettierSync.format("foo(", formatOptions);
+    synchronizedPrettier.format("foo(", formatOptions);
   } catch (formatError) {
     error = formatError;
   }
@@ -23,7 +23,7 @@ test("format", async () => {
 });
 
 test("version", () => {
-  assert.equal(prettierSync.version, prettier.version);
+  assert.equal(synchronizedPrettier.version, prettier.version);
 });
 
 {
@@ -37,10 +37,10 @@ test("version", () => {
     fileURLToPath(fakePrettierUrl),
   ]) {
     test(prettierEntry, async () => {
-      const fakePrettierSync = createSynchronizedPrettier({ prettierEntry });
-      assert.equal(fakePrettierSync.version, fakePrettier.version);
+      const fakeSynchronizedPrettier = createSynchronizedPrettier({ prettierEntry });
+      assert.equal(fakeSynchronizedPrettier.version, fakePrettier.version);
       assert.equal(
-        fakePrettierSync.format("code"),
+        fakeSynchronizedPrettier.format("code"),
         await fakePrettier.format("code"),
       );
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "target": "esnext",
+    "module": "NodeNext"
+  },
+  "files": ["index.cjs"]
+}


### PR DESCRIPTION
Great work on Prettier v3 🙌

Hope this PR is welcome, but I've added JSDoc + **tsconfig.json** to export type declarations

I followed the link in the [**Prettier 3.0: Hello, ECMAScript Modules!** blog post](https://prettier.io/blog/2023/07/05/3.0.0.html) after realising that the Prettier sync APIs would still be needed to avoid [Nunjucks template changes for asynchronous rendering](https://mozilla.github.io/nunjucks/api.html#asynchronous-support) 😣

>If you still need sync APIs, you can try [@prettier/sync](https://github.com/prettier/prettier-synchronized)

I'd be happy to make any tweaks, and wasn't sure if committing the types would be preferred

Closes: https://github.com/prettier/prettier-synchronized/issues/8