### PR TITLE
Add TypeScript type definitions

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -1,13 +1,16 @@
 import {
-  CursorOptions,
-  CursorResult,
-  FileInfoOptions,
-  FileInfoResult,
-  Options,
-  ResolveConfigOptions,
+  check,
+  clearConfigCache,
   doc,
+  format,
+  formatWithCursor,
+  getFileInfo,
+  resolveConfig,
+  resolveConfigFile,
   util,
 } from "prettier";
+
+type SyncFunction<T extends Function> = (...args: Parameters<T>) => Awaited<ReturnType<T>>
 
 declare namespace prettierSync {
   interface PrettierSync {
@@ -21,18 +24,18 @@ declare namespace prettierSync {
      * `check` checks to see if the file has been formatted with Prettier given those options and returns a `Boolean`.
      * This is similar to the `--list-different` parameter in the CLI and is useful for running Prettier in CI scenarios.
      */
-    check: (source: string, options?: Options | undefined) => boolean;
+    check: SyncFunction<typeof check>;
 
     /**
      * As you repeatedly call `resolveConfig`, the file system structure will be cached for performance. This function will clear the cache.
      * Generally this is only needed for editor integrations that know that the file system has changed since the last format took place.
      */
-    clearConfigCache: () => void;
+    clearConfigCache: SyncFunction<typeof clearConfigCache>
 
     /**
      * `format` is used to format text using Prettier. [Options](https://prettier.io/docs/en/options.html) may be provided to override the defaults.
      */
-    format: (source: string, options?: Options) => string;
+    format: SyncFunction<typeof format>
 
     /**
      * `formatWithCursor` both formats the code, and translates a cursor position from unformatted code to formatted code.
@@ -40,12 +43,9 @@ declare namespace prettierSync {
      *
      * The `cursorOffset` option should be provided, to specify where the cursor is. This option cannot be used with `rangeStart` and `rangeEnd`.
      */
-    formatWithCursor: (source: string, options: CursorOptions) => CursorResult;
+    formatWithCursor: SyncFunction<typeof formatWithCursor>
 
-    getFileInfo: (
-      filePath: string,
-      options?: FileInfoOptions,
-    ) => FileInfoResult;
+    getFileInfo: SyncFunction<typeof getFileInfo>
 
     /**
      * `resolveConfig` can be used to resolve configuration for a given source file,
@@ -60,10 +60,7 @@ declare namespace prettierSync {
      *
      * The promise will be rejected if there was an error parsing the configuration file.
      */
-    resolveConfig: (
-      filePath: string,
-      options?: ResolveConfigOptions,
-    ) => Options | null;
+    resolveConfig: SyncFunction<typeof resolveConfig>
 
     /**
      * `resolveConfigFile` can be used to find the path of the Prettier configuration file,
@@ -76,7 +73,7 @@ declare namespace prettierSync {
      *
      * The promise will be rejected if there was an error parsing the configuration file.
      */
-    resolveConfigFile: (filePath?: string) => string | null;
+    resolveConfigFile: SyncFunction<typeof resolveConfigFile>;
   }
 
   interface CreateSynchronizedPrettierOptions {

--- a/index.d.cts
+++ b/index.d.cts
@@ -1,0 +1,88 @@
+import {
+  CursorOptions,
+  CursorResult,
+  FileInfoOptions,
+  FileInfoResult,
+  Options,
+  ResolveConfigOptions,
+  doc,
+  util
+} from 'prettier'
+
+declare namespace prettierSync {
+  interface PrettierSync {
+    doc: typeof doc
+
+    util: typeof util
+
+    version: string
+
+    /**
+     * `check` checks to see if the file has been formatted with Prettier given those options and returns a `Boolean`.
+     * This is similar to the `--list-different` parameter in the CLI and is useful for running Prettier in CI scenarios.
+     */
+    check: (source: string, options?: Options | undefined) => boolean
+
+    /**
+     * As you repeatedly call `resolveConfig`, the file system structure will be cached for performance. This function will clear the cache.
+     * Generally this is only needed for editor integrations that know that the file system has changed since the last format took place.
+     */
+    clearConfigCache: () => void
+
+    /**
+     * `format` is used to format text using Prettier. [Options](https://prettier.io/docs/en/options.html) may be provided to override the defaults.
+     */
+    format: (source: string, options?: Options) => string
+
+    /**
+     * `formatWithCursor` both formats the code, and translates a cursor position from unformatted code to formatted code.
+     * This is useful for editor integrations, to prevent the cursor from moving when code is formatted.
+     *
+     * The `cursorOffset` option should be provided, to specify where the cursor is. This option cannot be used with `rangeStart` and `rangeEnd`.
+     */
+    formatWithCursor: (source: string, options: CursorOptions) => CursorResult
+
+    getFileInfo: (filePath: string, options?: FileInfoOptions) => FileInfoResult
+
+    /**
+     * `resolveConfig` can be used to resolve configuration for a given source file,
+     * passing its path as the first argument. The config search will start at the
+     * file path and continue to search up the directory.
+     * (You can use `process.cwd()` to start searching from the current directory).
+     *
+     * A promise is returned which will resolve to:
+     *
+     *  - An options object, providing a [config file](https://prettier.io/docs/en/configuration.html) was found.
+     *  - `null`, if no file was found.
+     *
+     * The promise will be rejected if there was an error parsing the configuration file.
+     */
+    resolveConfig: (filePath: string, options?: ResolveConfigOptions) => Options | null
+
+    /**
+     * `resolveConfigFile` can be used to find the path of the Prettier configuration file,
+     * that will be used when resolving the config (i.e. when calling `resolveConfig`).
+     *
+     * A promise is returned which will resolve to:
+     *
+     * - The path of the configuration file.
+     * - `null`, if no file was found.
+     *
+     * The promise will be rejected if there was an error parsing the configuration file.
+     */
+    resolveConfigFile: (filePath?: string) => string | null
+  }
+
+  interface CreateSynchronizedPrettierOptions {
+    /**
+     * Path or URL to prettier entry.
+     */
+    prettierEntry: string | URL
+  }
+}
+
+declare const prettierSync: prettierSync.PrettierSync & {
+  createSynchronizedPrettier: (options: CreateSynchronizedPrettierOptions) => prettierSync.PrettierSync
+}
+
+export = prettierSync

--- a/index.d.cts
+++ b/index.d.cts
@@ -86,7 +86,7 @@ declare namespace prettierSync {
 
 declare const prettierSync: prettierSync.PrettierSync & {
   createSynchronizedPrettier: (
-    options: CreateSynchronizedPrettierOptions,
+    options: prettierSync.CreateSynchronizedPrettierOptions,
   ) => prettierSync.PrettierSync;
 };
 

--- a/index.d.cts
+++ b/index.d.cts
@@ -6,33 +6,33 @@ import {
   Options,
   ResolveConfigOptions,
   doc,
-  util
-} from 'prettier'
+  util,
+} from "prettier";
 
 declare namespace prettierSync {
   interface PrettierSync {
-    doc: typeof doc
+    doc: typeof doc;
 
-    util: typeof util
+    util: typeof util;
 
-    version: string
+    version: string;
 
     /**
      * `check` checks to see if the file has been formatted with Prettier given those options and returns a `Boolean`.
      * This is similar to the `--list-different` parameter in the CLI and is useful for running Prettier in CI scenarios.
      */
-    check: (source: string, options?: Options | undefined) => boolean
+    check: (source: string, options?: Options | undefined) => boolean;
 
     /**
      * As you repeatedly call `resolveConfig`, the file system structure will be cached for performance. This function will clear the cache.
      * Generally this is only needed for editor integrations that know that the file system has changed since the last format took place.
      */
-    clearConfigCache: () => void
+    clearConfigCache: () => void;
 
     /**
      * `format` is used to format text using Prettier. [Options](https://prettier.io/docs/en/options.html) may be provided to override the defaults.
      */
-    format: (source: string, options?: Options) => string
+    format: (source: string, options?: Options) => string;
 
     /**
      * `formatWithCursor` both formats the code, and translates a cursor position from unformatted code to formatted code.
@@ -40,9 +40,12 @@ declare namespace prettierSync {
      *
      * The `cursorOffset` option should be provided, to specify where the cursor is. This option cannot be used with `rangeStart` and `rangeEnd`.
      */
-    formatWithCursor: (source: string, options: CursorOptions) => CursorResult
+    formatWithCursor: (source: string, options: CursorOptions) => CursorResult;
 
-    getFileInfo: (filePath: string, options?: FileInfoOptions) => FileInfoResult
+    getFileInfo: (
+      filePath: string,
+      options?: FileInfoOptions,
+    ) => FileInfoResult;
 
     /**
      * `resolveConfig` can be used to resolve configuration for a given source file,
@@ -57,7 +60,10 @@ declare namespace prettierSync {
      *
      * The promise will be rejected if there was an error parsing the configuration file.
      */
-    resolveConfig: (filePath: string, options?: ResolveConfigOptions) => Options | null
+    resolveConfig: (
+      filePath: string,
+      options?: ResolveConfigOptions,
+    ) => Options | null;
 
     /**
      * `resolveConfigFile` can be used to find the path of the Prettier configuration file,
@@ -70,19 +76,21 @@ declare namespace prettierSync {
      *
      * The promise will be rejected if there was an error parsing the configuration file.
      */
-    resolveConfigFile: (filePath?: string) => string | null
+    resolveConfigFile: (filePath?: string) => string | null;
   }
 
   interface CreateSynchronizedPrettierOptions {
     /**
      * Path or URL to prettier entry.
      */
-    prettierEntry: string | URL
+    prettierEntry: string | URL;
   }
 }
 
 declare const prettierSync: prettierSync.PrettierSync & {
-  createSynchronizedPrettier: (options: CreateSynchronizedPrettierOptions) => prettierSync.PrettierSync
-}
+  createSynchronizedPrettier: (
+    options: CreateSynchronizedPrettierOptions,
+  ) => prettierSync.PrettierSync;
+};
 
-export = prettierSync
+export = prettierSync;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "exports": "./index.cjs",
   "files": [
     "index.cjs",
+    "index.d.cts",
     "worker.js"
   ],
   "scripts": {


### PR DESCRIPTION
I had already created this before I saw #10. But after seeing https://github.com/prettier/prettier-synchronized/pull/10#issuecomment-1630012949, I felt like this is the approach @fisker was going for.

#10 has files generated from the JSDoc, then checked into source control. This PR contains handwritten type definitions that look a bit more clean, but at the cost of being handwritten and maintained separately.

Just pick the one you prefer. :)

Closes #8
Closes #10