### PR TITLE
Declare `createSynchronizedPrettier` as only named export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,9 @@
+type Prettier = typeof import("prettier");
+type SynchronizedPrettier = typeof import("./index.cjs");
+
+export function createSynchronizedPrettier(options: {
+  prettierEntry: string | URL;
+}): SynchronizedPrettier;
+
+declare const synchronizedPrettier: SynchronizedPrettier;
+export default synchronizedPrettier;

--- a/package.json
+++ b/package.json
@@ -19,8 +19,14 @@
   "main": "./index.cjs",
   "exports": {
     ".": {
-      "types": "./index.d.cts",
-      "default": "./index.cjs"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.cjs"
+      },
+      "require": {
+        "types": "./index.d.cts",
+        "default": "./index.cjs"
+      }
     },
     "./*": "./*"
   },

--- a/test.js
+++ b/test.js
@@ -36,7 +36,7 @@ test("version", () => {
     fakePrettierUrl.href,
     fileURLToPath(fakePrettierUrl),
   ]) {
-    test(prettierEntry, async () => {
+    test(prettierEntry.toString(), async () => {
       const fakeSynchronizedPrettier = createSynchronizedPrettier({
         prettierEntry,
       });

--- a/test.js
+++ b/test.js
@@ -36,7 +36,7 @@ test("version", () => {
     fakePrettierUrl.href,
     fileURLToPath(fakePrettierUrl),
   ]) {
-    test(prettierEntry.toString(), async () => {
+    test(String(prettierEntry), async () => {
       const fakeSynchronizedPrettier = createSynchronizedPrettier({
         prettierEntry,
       });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,9 @@
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,
-    "target": "esnext",
-    "module": "NodeNext"
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node"
   },
-  "files": ["index.cjs"]
+  "include": ["*.cjs", "*.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
+    "esModuleInterop": true,
     "noEmit": true,
     "target": "ESNext",
     "module": "ESNext",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "noEmit": true,
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "Node"
+    "moduleResolution": "NodeNext"
   },
   "include": ["*.cjs", "*.js"]
 }


### PR DESCRIPTION
As discussed in https://github.com/alphagov/govuk-frontend/pull/3971#discussion_r1265398678 `@prettier/sync` doesn't support named exports:

```mjs
import { format } from '@prettier/sync'
```

This PR updates the type declarations to show that

I've also updated the **tsconfig.json** file so local `test.js` imports are checked too

<img width="573" alt="Named exports not allowed" src="https://github.com/prettier/prettier-synchronized/assets/415517/8fb6cfd0-61b9-4260-ad65-cf4d6a4548b5">