### PR TITLE
docs: update readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ synchronizedPrettier.format("foo( )", { parser: "babel" });
 
 This package is a simple wrapper of [`make-synchronized`](https://github.com/fisker/make-synchronized).
 
-For more complex use cases, it more reasonable to extract functionality into a separate file, and run with [`make-synchronized`](https://github.com/fisker/make-synchronized), [`synckit`](https://github.com/un-ts/synckit), or [`make-synchronous`](https://github.com/sindresorhus/make-synchronous) etc.
+For more complex use cases, it's better to use [`make-synchronized`](https://github.com/fisker/make-synchronized) directly:
 
 Example:
 
@@ -52,6 +52,8 @@ export default makeSynchronized(import.meta, async function formatFile(file) {
   await fs.writeFile(file, formatted);
 });
 ```
+
+Alternatively you can also use [`synckit`](https://github.com/un-ts/synckit) or [`make-synchronous`](https://github.com/sindresorhus/make-synchronous).
 
 ### `createSynchronizedPrettier(options)`
 


### PR DESCRIPTION
This started as addressing the direct grammar mistake:

> For more complex use cases, it more reasonable to

But I felt this is arguably a more natural way to layout this section of the readme, given the example is showing off just `make-synchronized`.

If folks disagree I'm happy to roll this back to just fixing the immediate issue.